### PR TITLE
Support old repos still using 'master' as default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,7 @@ name: Test CI Stata
 
 on:
   push:
-    branches:
-      - main
+    branches: [main, master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
For https://github.com/lsms-worldbank/adodown that is also using GH Actions we found it to be more stable with older repos if both `main` and `master` is used as action trigger. 

Some people find it controversial to support the old name, but it tends to be the people that are still using that name that would probably find the hardest to solve this. Although, they might also not be likely to use GH Actions.

So feel free to close this PR without merging it. 